### PR TITLE
docs: add HungBil commercial licensing notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,75 @@
+# PolyForm Noncommercial License 1.0.0
+
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
+
+## Acceptance
+
+In order to get any license under these terms, you must agree to them as both strict obligations and conditions to all your licenses.
+
+## Copyright License
+
+The licensor grants you a copyright license for the software to do everything you might do with the software that would otherwise infringe the licensor's copyright in it for any permitted purpose.  However, you may only distribute the software according to [Distribution License](#distribution-license) and make changes or new works based on the software according to [Changes and New Works License](#changes-and-new-works-license).
+
+## Distribution License
+
+The licensor grants you an additional copyright license to distribute copies of the software.  Your license to distribute covers distributing the software with changes and new works permitted by [Changes and New Works License](#changes-and-new-works-license).
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you also gets a copy of these terms or the URL for them above, as well as copies of any plain-text lines beginning with `Required Notice:` that the licensor provided with the software.  For example:
+
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
+
+## Changes and New Works License
+
+The licensor grants you an additional copyright license to make changes and new works based on the software for any permitted purpose.
+
+## Patent License
+
+The licensor grants you a patent license for the software that covers patent claims the licensor can license, or becomes able to license, that you would infringe by using the software.
+
+## Noncommercial Purposes
+
+Any noncommercial purpose is a permitted purpose.
+
+## Personal Uses
+
+Personal use for research, experiment, and testing for the benefit of public knowledge, personal study, private entertainment, hobby projects, amateur pursuits, or religious observance, without any anticipated commercial application, is use for a permitted purpose.
+
+## Noncommercial Organizations
+
+Use by any charitable organization, educational institution, public research organization, public safety or health organization, environmental protection organization, or government institution is use for a permitted purpose regardless of the source of funding or obligations resulting from the funding.
+
+## Fair Use
+
+You may have "fair use" rights for the software under the law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of your licenses to anyone else, or prevent the licensor from granting licenses to anyone else.  These terms do not imply any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or contributes to infringement of any patent, your patent license for the software granted under these terms ends immediately. If your company makes such a claim, your patent license ends immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have violated any of these terms, or done anything with the software not covered by your licenses, your licenses can nonetheless continue if you come into full compliance with these terms, and take practical steps to correct past violations, within 32 days of receiving notice.  Otherwise, all your licenses end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without any warranty or condition, and the licensor will not be liable to you for any damages arising out of these terms or the use or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these terms, and the **software** is the software the licensor makes available under these terms.
+
+**You** refers to the individual or entity agreeing to these terms.
+
+**Your company** is any legal entity, sole proprietorship, or other kind of organization that you work for, plus all organizations that have control over, are under the control of, or are under common control with that organization.  **Control** means ownership of substantially all the assets of an entity, or the power to direct its management and policies by vote, contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the software under these terms.
+
+**Use** means anything you do with the software requiring one of your licenses.
+
+Required Notice: Copyright (c) 2026 HungBil

--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,23 @@
+# Licensing
+
+Copyright (c) 2026 HungBil.
+
+OpenHunterAI is source-available under the [PolyForm Noncommercial License
+1.0.0](LICENSE). It is not an OSI-approved open-source license.
+
+Personal study, research, education, experimentation, testing, and other
+noncommercial uses are permitted under the license terms. Commercial use,
+commercial hosting, paid services, resale, and inclusion in a paid product or
+service require a separate written commercial license from HungBil.
+
+For commercial licensing, contact HungBil through
+<https://github.com/HungBil>.
+
+The root license does not replace the licenses included with third-party
+components. In particular, `third_party_research/openhack/LICENSE` remains MIT
+and `third_party_research/strix/LICENSE` remains Apache-2.0. Read all
+applicable notices before distribution.
+
+External contribution terms and the rights for existing contributions require
+separate review. A pull request does not transfer copyright or grant a
+commercial relicensing right unless a separate written agreement says so.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ Technical requirements for OpenHunterAI's black-box pentest workflow and MVP arc
 > [mandatory security guardrails](docs/SECURITY_GUARDRAILS.md).
 > Raw credentials, HAR and sensitive request/response data are not report artifacts.
 
+## License
+
+OpenHunterAI is source-available under the [PolyForm Noncommercial License
+1.0.0](LICENSE). Commercial use requires a separate written license from
+HungBil. See [LICENSING.md](LICENSING.md).
+
 ## 1. Technical Scope
 
 - **Model**: AI Agentic Workflow — AI orchestrates, analyzes context, and chooses actions; open-source tools handle recon, crawling, request sending, OAST, and known-vulnerability checks.

--- a/docs/PUBLIC_RELEASE_READINESS.md
+++ b/docs/PUBLIC_RELEASE_READINESS.md
@@ -27,7 +27,8 @@ to their terms.
 
 Do not apply a new root license until these gates are met:
 
-- [ ] Owner confirms the actual legal licensor name and commercial contact.
+- [x] Owner confirmed the legal licensor: HungBil. Commercial inquiries route
+      through <https://github.com/HungBil>.
 - [ ] Confirm rights to the existing contributions. Git author names are not
       proof of employment, assignment or permission to relicense.
 - [ ] Inventory third-party code and retain its licenses/notices. In particular,

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -342,6 +342,12 @@ export function HomePage() {
       <footer className="border-t border-hairline">
         <div className="mx-auto flex max-w-7xl flex-wrap items-center justify-between gap-4 px-5 py-8 text-sm text-ink-faint lg:px-8">
           <span className="font-display font-700 text-ink">OpenHunterAI</span>
+          <a
+            className="underline decoration-hairline-strong underline-offset-4 hover:text-ink"
+            href="https://github.com/LumosLab-Innovation/OpenHunterAI/blob/main/LICENSING.md"
+          >
+            Source-available under PolyForm Noncommercial
+          </a>
           <span>Authorized external web/app security testing. Verified scope only.</span>
         </div>
       </footer>


### PR DESCRIPTION
## Summary\n- add the unmodified PolyForm Noncommercial 1.0.0 text with HungBil required notice\n- document commercial licensing contact and third-party license boundaries\n- expose the source-available license in the public homepage footer\n\n## Verification\n- official license text comparison passed\n- frontend typecheck passed\n- public-site build passed\n- third-party MIT and Apache-2.0 license files remain present\n\nThis is source-available licensing, not an OSI open-source license. Existing contributor-rights and CLA review remain recorded release gates.